### PR TITLE
updates to get CI passing again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: required
+addons:
+  postgresql: "9.5"
 language: python
 python:
   - "3.6"
@@ -11,5 +13,6 @@ script:
 services:
   - postgresql
   - docker
+  - redis-server
 env:
   - FLASK_ENV=ci

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -37,6 +37,9 @@ for repo in ${SERVICES[@]}; do
     mv $service-$version $service
     # "script/setup is typically run after an initial clone"
     cd $top/$service
+    curl -sSL https://github.com/dod-ccpo/scriptz/archive/master.tar.gz | tar xz
+    rm -rf script/include || true
+    mv scriptz-master script/include
     log=$top/log/$service.setup.log
     if [ -n "${CI}" ]; then
       echo -e "\tscript/setup: Starting output for $service";


### PR DESCRIPTION
- adds Postgres and redis-server to CI config
- adds some additional setup to `script/bootstrap` to apply the `scriptz` submodule